### PR TITLE
Register Event on Load

### DIFF
--- a/AntiVPN.cs
+++ b/AntiVPN.cs
@@ -15,8 +15,8 @@ public class AntiVPN : BasePlugin
     public override void Load(bool hotReload)
     {
         Config.CreateOrLoadConfig(ModuleDirectory + "/antivpn_config.json");
+        RegisterEventHandler<EventPlayerConnectFull>(OnPlayerConnectFull);
     }
-    [GameEventHandler]
     private HookResult OnPlayerConnectFull(EventPlayerConnectFull @event, GameEventInfo info)
     {
    	CCSPlayerController player = @event.Userid;


### PR DESCRIPTION
For some reason CounterStrikeSharp doesn't register event listener by using [GameEventHandler] in latest CSSharp versions. 
Small hotfix for that, with intention to awake plugin's author :D